### PR TITLE
adapt new interfaces && Supplementary transaction fetch

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -1,5 +1,5 @@
 hunter_config(bcos-framework
 VERSION 3.0.0-local
-URL "https://${URL_BASE}/FISCO-BCOS/bcos-framework/archive/e2e3363bbeef1d6d5c86a92ed591ce244270dcb7.tar.gz"
-SHA1 2ed159d0edbd50db31cb5aa466bfcd852981e543
+URL "https://${URL_BASE}/FISCO-BCOS/bcos-framework/archive/78eb4d2f54388abc7343bd82b569a215e0c56be8.tar.gz"
+SHA1 9a09e503539ce883c82633756f3f7fea257eb203
 )

--- a/src/TxPoolConfig.h
+++ b/src/TxPoolConfig.h
@@ -27,6 +27,7 @@
 #include <bcos-framework/interfaces/protocol/BlockFactory.h>
 #include <bcos-framework/interfaces/protocol/TransactionFactory.h>
 #include <bcos-framework/interfaces/protocol/TransactionSubmitResultFactory.h>
+#include <bcos-framework/interfaces/sealer/SealerInterface.h>
 namespace bcos
 {
 namespace txpool
@@ -39,12 +40,14 @@ public:
         bcos::protocol::TransactionSubmitResultFactory::Ptr _txResultFactory,
         bcos::protocol::TransactionFactory::Ptr _txFactory,
         bcos::protocol::BlockFactory::Ptr _blockFactory,
-        std::shared_ptr<bcos::ledger::LedgerInterface> _ledger)
+        std::shared_ptr<bcos::ledger::LedgerInterface> _ledger,
+        bcos::sealer::SealerInterface::Ptr _sealer)
       : m_txValidator(_txValidator),
         m_txResultFactory(_txResultFactory),
         m_txFactory(_txFactory),
         m_blockFactory(_blockFactory),
-        m_ledger(_ledger)
+        m_ledger(_ledger),
+        m_sealer(_sealer)
     {}
 
     virtual ~TxPoolConfig() {}
@@ -87,12 +90,15 @@ public:
 
     std::shared_ptr<bcos::ledger::LedgerInterface> ledger() { return m_ledger; }
 
+    bcos::sealer::SealerInterface::Ptr sealer() { return m_sealer; }
+
 private:
     TxValidatorInterface::Ptr m_txValidator;
     bcos::protocol::TransactionSubmitResultFactory::Ptr m_txResultFactory;
     bcos::protocol::TransactionFactory::Ptr m_txFactory;
     bcos::protocol::BlockFactory::Ptr m_blockFactory;
     std::shared_ptr<bcos::ledger::LedgerInterface> m_ledger;
+    bcos::sealer::SealerInterface::Ptr m_sealer;
     // TODO: create the nonceChecker
     NonceCheckerInterface::Ptr m_txPoolNonceChecker;
     NonceCheckerInterface::Ptr m_ledgerNonceChecker;

--- a/src/sync/TransactionSync.h
+++ b/src/sync/TransactionSync.h
@@ -74,9 +74,17 @@ protected:
 
     virtual void onReceiveTxsRequest(
         TxsSyncMsgInterface::Ptr _txsRequest, SendResponseCallback _sendResponse);
+
+    // functions called by requestMissedTxs
     virtual void verifyFetchedTxs(Error::Ptr _error, bcos::crypto::NodeIDPtr _nodeID,
         bytesConstRef _data, bcos::crypto::HashListPtr _missedTxs,
         VerifyResponseCallback _onVerifyFinished);
+    virtual void requestMissedTxsFromPeer(bcos::crypto::PublicPtr _generatedNodeID,
+        bcos::crypto::HashListPtr _missedTxs, VerifyResponseCallback _onVerifyFinished);
+    virtual size_t onGetMissedTxsFromLedger(std::set<bcos::crypto::HashType>& _missedTxs,
+        Error::Ptr _error, bcos::protocol::TransactionsPtr _fetchedTxs,
+        VerifyResponseCallback _onVerifyFinished);
+
 
     virtual bool downloadTxsBufferEmpty()
     {
@@ -100,6 +108,9 @@ protected:
     }
     virtual bool importDownloadedTxs(
         bcos::crypto::NodeIDPtr _fromNode, bcos::protocol::Block::Ptr _txsBuffer);
+
+    virtual bool importDownloadedTxs(
+        bcos::crypto::NodeIDPtr _fromNode, bcos::protocol::TransactionsPtr _txs);
 
     void noteNewTransactions()
     {

--- a/src/sync/TransactionSyncConfig.h
+++ b/src/sync/TransactionSyncConfig.h
@@ -23,6 +23,7 @@
 #include <bcos-framework/interfaces/consensus/ConsensusNodeInterface.h>
 #include <bcos-framework/interfaces/crypto/KeyInterface.h>
 #include <bcos-framework/interfaces/front/FrontServiceInterface.h>
+#include <bcos-framework/interfaces/ledger/LedgerInterface.h>
 #include <bcos-framework/interfaces/protocol/BlockFactory.h>
 #include <bcos-framework/libsync/interfaces/TxsSyncMsgFactory.h>
 namespace bcos
@@ -38,6 +39,7 @@ public:
         bcos::txpool::TxPoolStorageInterface::Ptr _txpoolStorage,
         bcos::sync::TxsSyncMsgFactory::Ptr _msgFactory,
         bcos::protocol::BlockFactory::Ptr _blockFactory,
+        std::shared_ptr<bcos::ledger::LedgerInterface> _ledger,
         bcos::consensus::ConsensusNodeList const& _consensusNodes,
         bcos::consensus::ConsensusNodeList const& _observerNodes)
       : m_nodeId(_nodeId),
@@ -45,6 +47,7 @@ public:
         m_txpoolStorage(_txpoolStorage),
         m_msgFactory(_msgFactory),
         m_blockFactory(_blockFactory),
+        m_ledger(_ledger),
         m_consensusNodeList(std::make_shared<bcos::consensus::ConsensusNodeList>(_consensusNodes)),
         m_observerNodeList(std::make_shared<bcos::consensus::ConsensusNodeList>(_observerNodes)),
         m_nodeList(std::make_shared<bcos::crypto::NodeIDSet>())
@@ -131,6 +134,7 @@ public:
         ReadGuard l(x_nodeList);
         return m_nodeList->count(m_nodeId);
     }
+    std::shared_ptr<bcos::ledger::LedgerInterface> ledger() { return m_ledger; }
 
 private:
     void updateNodeList()
@@ -150,8 +154,9 @@ private:
     bcos::txpool::TxPoolStorageInterface::Ptr m_txpoolStorage;
     bcos::sync::TxsSyncMsgFactory::Ptr m_msgFactory;
     bcos::protocol::BlockFactory::Ptr m_blockFactory;
+    std::shared_ptr<bcos::ledger::LedgerInterface> m_ledger;
 
-    // TODO: fetch the consensusNodeList
+    // TODO: fetch the consensusNodeList through initializer
     bcos::consensus::ConsensusNodeListPtr m_consensusNodeList;
     SharedMutex x_consensusNodeList;
 

--- a/src/txpool/interfaces/TxPoolStorageInterface.h
+++ b/src/txpool/interfaces/TxPoolStorageInterface.h
@@ -39,7 +39,8 @@ public:
     virtual bcos::protocol::TransactionStatus submitTransaction(
         bytesPointer _txData, bcos::protocol::TxSubmitCallback _txSubmitCallback = nullptr) = 0;
     virtual bcos::protocol::TransactionStatus submitTransaction(
-        bcos::protocol::Transaction::ConstPtr _tx) = 0;
+        bcos::protocol::Transaction::Ptr _tx,
+        bcos::protocol::TxSubmitCallback _txSubmitCallback = nullptr) = 0;
 
     virtual bcos::protocol::TransactionStatus insert(bcos::protocol::Transaction::ConstPtr _tx) = 0;
     virtual void batchInsert(bcos::protocol::Transactions const& _txs) = 0;
@@ -61,7 +62,7 @@ public:
      * @return List of new transactions
      */
     virtual bcos::protocol::ConstTransactionsPtr fetchNewTxs(size_t _txsLimit) = 0;
-    virtual bcos::protocol::ConstTransactionsPtr batchFetchTxs(
+    virtual bcos::crypto::HashListPtr batchFetchTxs(
         size_t _txsLimit, TxsHashSetPtr _avoidTxs, bool _avoidDuplicate = true) = 0;
 
     virtual bool exist(bcos::crypto::HashType const& _txHash) = 0;
@@ -78,6 +79,9 @@ public:
     {
         return m_onReady.add(_t);
     }
+
+    virtual void batchMarkTxs(bcos::crypto::HashList const& _txsHashList, bool _sealFlag) = 0;
+    virtual size_t unSealedTxsSize() = 0;
 
 protected:
     bcos::CallbackCollectionHandler<> m_onReady;

--- a/src/txpool/validator/TxValidator.cpp
+++ b/src/txpool/validator/TxValidator.cpp
@@ -26,7 +26,6 @@ using namespace bcos::txpool;
 
 TransactionStatus TxValidator::verify(bcos::protocol::Transaction::ConstPtr _tx)
 {
-    // TODO: check the node in belongs to the group or not
     if (_tx->invalid())
     {
         return TransactionStatus::InvalidSignature;
@@ -48,10 +47,7 @@ TransactionStatus TxValidator::verify(bcos::protocol::Transaction::ConstPtr _tx)
     // check signature
     try
     {
-        if (!_tx->verify())
-        {
-            throw bcos::Exception("Hash verify failed!");
-        }
+        _tx->verify();
     }
     catch (std::exception const& e)
     {


### PR DESCRIPTION
1. Add the asyncMarkTxs interface to the txpool to mark the sealed txs

2. fetch transactions from the local txpool when verifyBlock
3. add `notifyUnsealedTxsSize` to notify the unsealed transactions size