### PR TITLE
add batchVerifyProposal && re-fetch the missed txs when request txs finished

### DIFF
--- a/bcos-txpool/TxPool.cpp
+++ b/bcos-txpool/TxPool.cpp
@@ -111,14 +111,18 @@ void TxPool::asyncVerifyBlock(PublicPtr _generatedNodeID, bytesConstRef const& _
     TXPOOL_LOG(INFO) << LOG_DESC("begin asyncVerifyBlock")
                      << LOG_KV(
                             "consNum", block->blockHeader() ? block->blockHeader()->number() : -1);
-
-    auto onVerifyFinishedWrapper = [_onVerifyFinished, block](Error::Ptr _error, bool _ret) {
+    auto startT = utcTime();
+    auto onVerifyFinishedWrapper = [_onVerifyFinished, block, startT](
+                                       Error::Ptr _error, bool _ret) {
         TXPOOL_LOG(INFO) << LOG_DESC("asyncVerifyBlock finished")
                          << LOG_KV("consNum",
                                 block->blockHeader() ? block->blockHeader()->number() : -1)
+                         << LOG_KV("hash", block->blockHeader() ?
+                                               block->blockHeader()->hash().abridged() :
+                                               "unknown")
                          << LOG_KV("code", _error ? _error->errorCode() : 0)
                          << LOG_KV("msg", _error ? _error->errorMessage() : "success")
-                         << LOG_KV("result", _ret);
+                         << LOG_KV("result", _ret) << LOG_KV("timecost", (utcTime() - startT));
         if (!_onVerifyFinished)
         {
             return;

--- a/bcos-txpool/TxPool.cpp
+++ b/bcos-txpool/TxPool.cpp
@@ -111,54 +111,60 @@ void TxPool::asyncVerifyBlock(PublicPtr _generatedNodeID, bytesConstRef const& _
     TXPOOL_LOG(INFO) << LOG_DESC("begin asyncVerifyBlock")
                      << LOG_KV(
                             "consNum", block->blockHeader() ? block->blockHeader()->number() : -1);
-    auto startT = utcTime();
-    auto onVerifyFinishedWrapper = [_onVerifyFinished, block, startT](
-                                       Error::Ptr _error, bool _ret) {
-        TXPOOL_LOG(INFO) << LOG_DESC("asyncVerifyBlock finished")
-                         << LOG_KV("consNum",
-                                block->blockHeader() ? block->blockHeader()->number() : -1)
-                         << LOG_KV("hash", block->blockHeader() ?
-                                               block->blockHeader()->hash().abridged() :
-                                               "unknown")
-                         << LOG_KV("code", _error ? _error->errorCode() : 0)
-                         << LOG_KV("msg", _error ? _error->errorMessage() : "success")
-                         << LOG_KV("result", _ret) << LOG_KV("timecost", (utcTime() - startT));
-        if (!_onVerifyFinished)
-        {
-            return;
-        }
-        _onVerifyFinished(_error, _ret);
-    };
     // Note: here must has thread pool for lock in the callback
     // use single thread here to decrease thread competition
     auto self = std::weak_ptr<TxPool>(shared_from_this());
-    m_verifier->enqueue([self, _generatedNodeID, block, onVerifyFinishedWrapper]() {
+    m_verifier->enqueue([self, _generatedNodeID, block, _onVerifyFinished]() {
         try
         {
+            auto startT = utcTime();
             auto txpool = self.lock();
             if (!txpool)
             {
-                onVerifyFinishedWrapper(
-                    std::make_shared<Error>(-1, "asyncVerifyBlock failed for lock txpool failed"),
-                    false);
-                return;
-            }
-            size_t txsSize = block->transactionsHashSize();
-            if (txsSize == 0)
-            {
-                onVerifyFinishedWrapper(nullptr, true);
-                return;
-            }
-            auto missedTxs = std::make_shared<HashList>();
-            auto txpoolStorage = txpool->m_txpoolStorage;
-            for (size_t i = 0; i < txsSize; i++)
-            {
-                auto txHash = block->transactionHash(i);
-                if (!(txpoolStorage->exist(txHash)))
+                if (_onVerifyFinished)
                 {
-                    missedTxs->emplace_back(txHash);
+                    _onVerifyFinished(std::make_shared<Error>(
+                                          -1, "asyncVerifyBlock failed for lock txpool failed"),
+                        false);
                 }
+                return;
             }
+            auto txpoolStorage = txpool->m_txpoolStorage;
+            auto missedTxs = txpoolStorage->batchVerifyProposal(block);
+            auto onVerifyFinishedWrapper = [txpoolStorage, _onVerifyFinished, block, missedTxs,
+                                               startT](Error::Ptr _error, bool _ret) {
+                auto verifyRet = _ret;
+                auto verifyError = _error;
+                if (missedTxs->size() > 0)
+                {
+                    // try to fetch the missed txs from the local  txpool again
+                    if (_error && _error->errorCode() == CommonError::TransactionsMissing)
+                    {
+                        verifyRet = txpoolStorage->batchVerifyProposal(missedTxs);
+                    }
+                    if (verifyRet)
+                    {
+                        verifyError = nullptr;
+                    }
+                }
+                TXPOOL_LOG(INFO) << LOG_DESC("asyncVerifyBlock finished")
+                                 << LOG_KV("consNum",
+                                        block->blockHeader() ? block->blockHeader()->number() : -1)
+                                 << LOG_KV("hash", block->blockHeader() ?
+                                                       block->blockHeader()->hash().abridged() :
+                                                       "unknown")
+                                 << LOG_KV("code", verifyError ? verifyError->errorCode() : 0)
+                                 << LOG_KV("msg",
+                                        verifyError ? verifyError->errorMessage() : "success")
+                                 << LOG_KV("result", verifyRet)
+                                 << LOG_KV("timecost", (utcTime() - startT));
+                if (!_onVerifyFinished)
+                {
+                    return;
+                }
+                _onVerifyFinished(verifyError, verifyRet);
+            };
+
             if (missedTxs->size() == 0)
             {
                 TXPOOL_LOG(DEBUG) << LOG_DESC("asyncVerifyBlock: hit all transactions in txpool")
@@ -172,7 +178,7 @@ void TxPool::asyncVerifyBlock(PublicPtr _generatedNodeID, bytesConstRef const& _
             TXPOOL_LOG(DEBUG) << LOG_DESC("asyncVerifyBlock")
                               << LOG_KV("consNum",
                                      block->blockHeader() ? block->blockHeader()->number() : -1)
-                              << LOG_KV("totalTxs", txsSize)
+                              << LOG_KV("totalTxs", block->transactionsHashSize())
                               << LOG_KV("missedTxs", missedTxs->size());
             txpool->m_transactionSync->requestMissedTxs(
                 _generatedNodeID, missedTxs, block, onVerifyFinishedWrapper);

--- a/bcos-txpool/sync/TransactionSync.cpp
+++ b/bcos-txpool/sync/TransactionSync.cpp
@@ -329,11 +329,11 @@ void TransactionSync::verifyFetchedTxs(Error::Ptr _error, NodeIDPtr _nodeID, byt
 {
     if (_error != nullptr)
     {
-        SYNC_LOG(WARNING) << LOG_DESC("asyncVerifyBlock: fetch missed txs failed")
-                          << LOG_KV("peer", _nodeID ? _nodeID->shortHex() : "unknown")
-                          << LOG_KV("missedTxsSize", _missedTxs->size())
-                          << LOG_KV("errorCode", _error->errorCode())
-                          << LOG_KV("errorMsg", _error->errorMessage());
+        SYNC_LOG(INFO) << LOG_DESC("asyncVerifyBlock: fetch missed txs failed")
+                       << LOG_KV("peer", _nodeID ? _nodeID->shortHex() : "unknown")
+                       << LOG_KV("missedTxsSize", _missedTxs->size())
+                       << LOG_KV("errorCode", _error->errorCode())
+                       << LOG_KV("errorMsg", _error->errorMessage());
         _onVerifyFinished(_error, false);
         return;
     }
@@ -355,17 +355,17 @@ void TransactionSync::verifyFetchedTxs(Error::Ptr _error, NodeIDPtr _nodeID, byt
     auto transactions = m_config->blockFactory()->createBlock(txsResponse->txsData(), true, false);
     if (_missedTxs->size() != transactions->transactionsSize())
     {
-        SYNC_LOG(WARNING) << LOG_DESC("verifyFetchedTxs failed")
-                          << LOG_KV("expectedTxs", _missedTxs->size())
-                          << LOG_KV("fetchedTxs", transactions->transactionsSize())
-                          << LOG_KV(
-                                 "hash", (_verifiedProposal && _verifiedProposal->blockHeader()) ?
+        SYNC_LOG(INFO) << LOG_DESC("verifyFetchedTxs failed")
+                       << LOG_KV("expectedTxs", _missedTxs->size())
+                       << LOG_KV("fetchedTxs", transactions->transactionsSize())
+                       << LOG_KV("peer", _nodeID->shortHex())
+                       << LOG_KV("hash", (_verifiedProposal && _verifiedProposal->blockHeader()) ?
                                              _verifiedProposal->blockHeader()->hash().abridged() :
                                              "unknown")
-                          << LOG_KV("consNum",
-                                 (_verifiedProposal && _verifiedProposal->blockHeader()) ?
-                                     _verifiedProposal->blockHeader()->number() :
-                                     -1);
+                       << LOG_KV(
+                              "consNum", (_verifiedProposal && _verifiedProposal->blockHeader()) ?
+                                             _verifiedProposal->blockHeader()->number() :
+                                             -1);
         // response the verify result
         _onVerifyFinished(
             std::make_shared<Error>(CommonError::TransactionsMissing, "TransactionsMissing"),

--- a/bcos-txpool/sync/TransactionSyncConfig.h
+++ b/bcos-txpool/sync/TransactionSyncConfig.h
@@ -68,7 +68,8 @@ private:
     bcos::protocol::BlockFactory::Ptr m_blockFactory;
     std::shared_ptr<bcos::ledger::LedgerInterface> m_ledger;
 
-    unsigned m_networkTimeout = 3000;
+    // set networkTimeout to 500ms
+    unsigned m_networkTimeout = 500;
 
     unsigned m_forwardPercent = 25;
 };

--- a/bcos-txpool/txpool/interfaces/TxPoolStorageInterface.h
+++ b/bcos-txpool/txpool/interfaces/TxPoolStorageInterface.h
@@ -98,6 +98,11 @@ public:
     virtual void stop() = 0;
     virtual void printPendingTxs() {}
 
+    virtual std::shared_ptr<bcos::crypto::HashList> batchVerifyProposal(
+        bcos::protocol::Block::Ptr _block) = 0;
+
+    virtual bool batchVerifyProposal(std::shared_ptr<bcos::crypto::HashList> _txsHashList) = 0;
+
 protected:
     bcos::CallbackCollectionHandler<> m_onReady;
     // notify the sealer the latest unsealed txs

--- a/bcos-txpool/txpool/storage/MemoryStorage.cpp
+++ b/bcos-txpool/txpool/storage/MemoryStorage.cpp
@@ -95,6 +95,10 @@ TransactionStatus MemoryStorage::enforceSubmitTransaction(Transaction::Ptr _tx)
         if (m_txsTable.count(txHash))
         {
             auto tx = m_txsTable[txHash];
+            if (!tx)
+            {
+                continue;
+            }
             if (!tx->sealed())
             {
                 m_sealedTxsSize++;
@@ -629,6 +633,10 @@ void MemoryStorage::batchMarkTxs(
             continue;
         }
         auto tx = m_txsTable[txHash];
+        if (!tx)
+        {
+            continue;
+        }
         // the tx has already been re-sealed, can not enforce unseal
         if (tx->batchHash() != HashType() && tx->batchHash() != _batchHash && !_sealFlag)
         {
@@ -665,10 +673,11 @@ void MemoryStorage::batchMarkAllTxs(bool _sealFlag)
     for (auto item : m_txsTable)
     {
         auto tx = item.second;
-        if (tx)
+        if (!tx)
         {
-            tx->setSealed(_sealFlag);
+            continue;
         }
+        tx->setSealed(_sealFlag);
         if (!_sealFlag)
         {
             tx->setBatchId(-1);

--- a/bcos-txpool/txpool/storage/MemoryStorage.h
+++ b/bcos-txpool/txpool/storage/MemoryStorage.h
@@ -93,6 +93,11 @@ public:
 
     void printPendingTxs() override;
 
+    std::shared_ptr<bcos::crypto::HashList> batchVerifyProposal(
+        bcos::protocol::Block::Ptr _block) override;
+
+    bool batchVerifyProposal(std::shared_ptr<bcos::crypto::HashList> _txsHashList) override;
+
 protected:
     bcos::protocol::TransactionStatus enforceSubmitTransaction(
         bcos::protocol::Transaction::Ptr _tx);


### PR DESCRIPTION

1. add batchVerifyProposal && re-fetch the missed txs when request txs finished
2. fix coredump caused by access element of tbb container without determine empty pointer